### PR TITLE
Update Minimessage to adventure-text

### DIFF
--- a/compatibility/pom.xml
+++ b/compatibility/pom.xml
@@ -8,6 +8,6 @@
     <parent>
         <groupId>de.erethon.commons</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>6.2.2</version>
+        <version>6.2.3</version>
     </parent>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.erethon.commons</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>6.2.2</version>
+        <version>6.2.3</version>
     </parent>
     <build>
         <resources>

--- a/core/src/main/java/de/erethon/commons/chat/MessageUtil.java
+++ b/core/src/main/java/de/erethon/commons/chat/MessageUtil.java
@@ -15,7 +15,8 @@ package de.erethon.commons.chat;
 import de.erethon.commons.compatibility.CompatibilityHandler;
 import de.erethon.commons.compatibility.Internals;
 import de.erethon.commons.javaplugin.DREPlugin;
-import me.minidigger.minimessage.bungee.MiniMessageParser;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -330,7 +331,9 @@ public class MessageUtil {
      */
     public static BaseComponent[] parse(String string) {
         string = ChatColor.translateAlternateColorCodes('&', string);
-        return is1_16 ? MiniMessageParser.parseFormat(string) : TextComponent.fromLegacyText(string);
+        // This is necessary until we do a full update to adventure-text
+        return is1_16 ? BungeeComponentSerializer.get().serialize(MiniMessage.get().parse(string)) : TextComponent.fromLegacyText(string);
+
     }
 
 }

--- a/craftbukkit_1_10_R1/pom.xml
+++ b/craftbukkit_1_10_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.erethon.commons</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>6.2.2</version>
+        <version>6.2.3</version>
     </parent>
     <dependencies>
         <dependency>

--- a/craftbukkit_1_8_R1/pom.xml
+++ b/craftbukkit_1_8_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.erethon.commons</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>6.2.2</version>
+        <version>6.2.3</version>
     </parent>
     <dependencies>
         <dependency>

--- a/craftbukkit_1_8_R2/pom.xml
+++ b/craftbukkit_1_8_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.erethon.commons</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>6.2.2</version>
+        <version>6.2.3</version>
     </parent>
     <dependencies>
         <dependency>

--- a/craftbukkit_1_8_R3/pom.xml
+++ b/craftbukkit_1_8_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.erethon.commons</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>6.2.2</version>
+        <version>6.2.3</version>
     </parent>
     <dependencies>
         <dependency>

--- a/craftbukkit_1_9_R1/pom.xml
+++ b/craftbukkit_1_9_R1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.erethon.commons</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>6.2.2</version>
+        <version>6.2.3</version>
     </parent>
     <dependencies>
         <dependency>

--- a/craftbukkit_1_9_R2/pom.xml
+++ b/craftbukkit_1_9_R2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.erethon.commons</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>6.2.2</version>
+        <version>6.2.3</version>
     </parent>
     <dependencies>
         <dependency>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -27,7 +27,6 @@
                                     <include>de.erethon.commons:*</include>
                                     <include>org.bstats:bstats-bukkit</include>
                                     <include>org.inventivetalent.spiget-update</include>
-                                    <include>me.minidigger:minimessage-bungee</include>
                                     <include>net.kyori:*</include>
                                 </includes>
                             </artifactSet>
@@ -39,10 +38,6 @@
                                 <relocation>
                                     <pattern>org.inventivetalent.update.spiget</pattern>
                                     <shadedPattern>de.erethon.commons.spiget</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>me.minidigger.minimessage</pattern>
-                                    <shadedPattern>de.erethon.commons.minimessage</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>net.kyori.adventure.*</pattern>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -28,6 +28,7 @@
                                     <include>org.bstats:bstats-bukkit</include>
                                     <include>org.inventivetalent.spiget-update</include>
                                     <include>me.minidigger:minimessage-bungee</include>
+                                    <include>net.kyori:*</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
@@ -42,6 +43,10 @@
                                 <relocation>
                                     <pattern>me.minidigger.minimessage</pattern>
                                     <shadedPattern>de.erethon.commons.minimessage</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.kyori.adventure.*</pattern>
+                                    <shadedPattern>de.erethon.commons.adventure.*</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>de.erethon.commons</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>6.2.2</version>
+        <version>6.2.3</version>
     </parent>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,13 @@
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
             <version>4.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-bungeecord</artifactId>
             <version>4.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.milkbowl.vault</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,14 +42,12 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
-            <scope>compile</scope>
+            <version>4.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-bungeecord</artifactId>
             <version>4.0.0-SNAPSHOT</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.milkbowl.vault</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.erethon.commons</groupId>
     <artifactId>commons-parent</artifactId>
-    <version>6.2.2</version>
+    <version>6.2.3</version>
     <packaging>pom</packaging>
     <name>DRECommons</name>
     <url>https://dre2n.github.io</url>
@@ -40,10 +40,14 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>me.minidigger</groupId>
-            <artifactId>minimessage-bungee</artifactId>
-            <version>2.1.0</version>
-            <scope>compile</scope>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-minimessage</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-serializer-bungeecord</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>net.milkbowl.vault</groupId>


### PR DESCRIPTION
Minimessage gehört nun zu adventure-text. Dementsprechend hab ich es geupdatet und jetzt geht auch sämtliches fancy 1.16-formatting so wie es soll. Leider erhöht das die Library-Größe deutlich, was etwas schade ist. Sobald Paper adventure selbst implementiert, könnte man es allerdings mit DRECommons nicht mehr shaden (https://github.com/PaperMC/Paper/pull/4842). 

FXL nutzt es schon, wir können aber mit dem PR auch einfach warten bis Paper das implementiert, dann werden die jars nicht so groß.