### PR TITLE
Fixed infinite-loop and added a color() method that translates color codes into ChatColor

### DIFF
--- a/core/src/main/java/de/erethon/commons/chat/MessageUtil.java
+++ b/core/src/main/java/de/erethon/commons/chat/MessageUtil.java
@@ -26,14 +26,17 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * @author Daniel Saukel
  */
 public class MessageUtil {
 
-    private static boolean is1_9 = Internals.isAtLeast(Internals.v1_9_R1);
-    private static boolean is1_11 = Internals.isAtLeast(Internals.v1_11_R1);
-    private static boolean is1_16 = Internals.isAtLeast(Internals.v1_16_R1);
+    private static final boolean is1_9 = Internals.isAtLeast(Internals.v1_9_R1);
+    private static final boolean is1_11 = Internals.isAtLeast(Internals.v1_11_R1);
+    private static final boolean is1_16 = Internals.isAtLeast(Internals.v1_16_R1);
 
     static InternalsProvider internals;
 
@@ -152,7 +155,7 @@ public class MessageUtil {
      * @param message the message String
      */
     public static void broadcastActionBarMessage(String message) {
-        broadcastActionBarMessage(message);
+        Bukkit.getOnlinePlayers().forEach(p -> sendActionBarMessage(p, message));
     }
 
     /**
@@ -333,4 +336,25 @@ public class MessageUtil {
         return is1_16 ? MiniMessageParser.parseFormat(string) : TextComponent.fromLegacyText(string);
     }
 
+    private static final Pattern pattern = Pattern.compile("#[a-fA-F0-9]{6}");
+
+    /**
+     * Colors the string
+     * <p>
+     * Translates color codes and in 1.16+ hex color as well
+     *
+     * @param string the String to parse
+     * @return the colored string
+     */
+    public static String color(String string) {
+        if (is1_16) {
+            Matcher match = pattern.matcher(string);
+            while (match.find()) {
+                String color = string.substring(match.start(), match.end());
+                string = string.replace(color, ChatColor.of(color) + "");
+                match = pattern.matcher(string);
+            }
+        }
+        return ChatColor.translateAlternateColorCodes('&', string);
+    }
 }


### PR DESCRIPTION
MessageUtil.parse(String string) gibt einem ein BaseComponent array zurück, welchen man nicht zum setzen von Spieler-, Gegenstand- oder sonstigen Namen verwenden kann. Da MiniMessage dies ebenfalls nicht kann, habe ich selber eine kleine Methode dafür geschrieben. 

Außerdem hat broadcastActionBarMessage(String message) in einer unendlichen Schleife geendet, da es sich immer wieder selbst aufgerufen hat, ohne etwas zu tun. 