### PR TITLE
Added basic TabCompletion for sub-commands

### DIFF
--- a/core/src/main/java/de/erethon/commons/command/CommandCache.java
+++ b/core/src/main/java/de/erethon/commons/command/CommandCache.java
@@ -36,6 +36,9 @@ public class CommandCache {
         return this.commands;
     }
 
+    /**
+     * @param commands the commands to add
+     */
     public void addCommands(DRECommand... commands) {
         for (DRECommand command : commands) {
             addCommand(command);

--- a/core/src/main/java/de/erethon/commons/command/CommandCache.java
+++ b/core/src/main/java/de/erethon/commons/command/CommandCache.java
@@ -2,9 +2,12 @@ package de.erethon.commons.command;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.function.Consumer;
 
-public class CommandCache {
+public class CommandCache implements Iterable<DRECommand> {
 
     protected final Set<DRECommand> commands;
 
@@ -57,5 +60,20 @@ public class CommandCache {
      */
     public void removeCommand(DRECommand command) {
         this.commands.remove(command);
+    }
+
+    @Override
+    public Iterator<DRECommand> iterator() {
+        return commands.iterator();
+    }
+
+    @Override
+    public void forEach(Consumer<? super DRECommand> action) {
+        commands.forEach(action);
+    }
+
+    @Override
+    public Spliterator<DRECommand> spliterator() {
+        return commands.spliterator();
     }
 }

--- a/core/src/main/java/de/erethon/commons/command/CommandCache.java
+++ b/core/src/main/java/de/erethon/commons/command/CommandCache.java
@@ -1,0 +1,58 @@
+package de.erethon.commons.command;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class CommandCache {
+
+    protected final Set<DRECommand> commands;
+
+    public CommandCache(Set<DRECommand> commands) {
+        this.commands = commands;
+    }
+
+    public CommandCache(DRECommand... commands) {
+        this.commands = new HashSet<>(Arrays.asList(commands));
+    }
+
+    /**
+     * @param commandName usually the first command argument
+     * @return the command with the given name
+     */
+    public DRECommand getCommand(String commandName) {
+        for (DRECommand command : commands) {
+            if (command.getCommand().equalsIgnoreCase(commandName) || command.getAliases().contains(commandName)) {
+                return command;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return the commands
+     */
+    public Set<DRECommand> getCommands() {
+        return this.commands;
+    }
+
+    public void addCommands(DRECommand... commands) {
+        for (DRECommand command : commands) {
+            addCommand(command);
+        }
+    }
+
+    /**
+     * @param command the command to add
+     */
+    public void addCommand(DRECommand command) {
+        this.commands.add(command);
+    }
+
+    /**
+     * @param command the command to remove
+     */
+    public void removeCommand(DRECommand command) {
+        this.commands.remove(command);
+    }
+}

--- a/core/src/main/java/de/erethon/commons/command/DRECommand.java
+++ b/core/src/main/java/de/erethon/commons/command/DRECommand.java
@@ -13,14 +13,21 @@
 package de.erethon.commons.command;
 
 import de.erethon.commons.chat.MessageUtil;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+
+import de.erethon.commons.config.CommonMessage;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.Player;
 
 /**
- * @author Daniel Saukel
+ * @author Daniel Saukel, Fyreum
  */
 public abstract class DRECommand {
 
@@ -32,18 +39,129 @@ public abstract class DRECommand {
     private String permission;
     private boolean playerCommand;
     private boolean consoleCommand;
+    private final CommandCache subCommands = new CommandCache();
 
     public void displayHelp(CommandSender sender) {
         MessageUtil.sendMessage(sender, ChatColor.RED + help);
     }
 
+    public void addSubCommand(DRECommand command) {
+        subCommands.addCommand(command);
+    }
+
+    public void addSubCommands(DRECommand... commands) {
+        subCommands.addCommands(commands);
+    }
+
+    /**
+     * @param arg the arg to check
+     *
+     * @return true if the name or one alias matches the arg
+     */
+    public boolean matches(String arg) {
+        return arg.equalsIgnoreCase(command) | aliases.contains(arg);
+    }
+
     /**
      * @param sender the sender to check
+     *
      * @return if the sender has permission to use the command
      */
     public boolean senderHasPermissions(CommandSender sender) {
         return permission == null || permission.isEmpty() || sender.hasPermission(permission);
     }
+
+    /**
+     * Returns a list of strings to tab complete including all sub commands of this class.
+     *
+     * @param sender the command sender
+     * @param args the given args
+     *
+     * @return a list of strings to tab complete including all sub commands
+     */
+    public final List<String> tabComplete(CommandSender sender, String[] args) {
+        List<String> completes = new ArrayList<>();
+        List<String> commandCompletes = onTabComplete(sender, args);
+        String cmd = args[0];
+
+        if (commandCompletes != null) {
+            completes.addAll(commandCompletes);
+        }
+
+        if(args.length == 1) {
+            List<String> cmds = new ArrayList<>();
+            for (DRECommand command : subCommands.getCommands()) {
+                if (command.senderHasPermissions(sender)) {
+                    cmds.add(command.getCommand());
+                }
+            }
+            for(String string : cmds) {
+                if(string.toLowerCase().startsWith(cmd.toLowerCase())) {
+                    completes.add(string);
+                }
+            }
+            return completes;
+        }
+        for (DRECommand command : subCommands.getCommands()) {
+            if (command.matches(cmd)) {
+                completes.addAll(command.tabComplete(sender, Arrays.copyOfRange(args, 1, args.length)));
+            }
+        }
+        return completes;
+    }
+
+    /**
+     * Returns a list of strings to tab complete.
+     * The returned value can be null.
+     * This method will most likely be overridden by the certain command.
+     *
+     * @param sender the command sender
+     * @param args the given args
+     *
+     * @return a list of strings to tab complete
+     */
+    public List<String> onTabComplete(CommandSender sender, String[] args) {
+        return null;
+    }
+
+    public final void execute(String[] args, CommandSender sender) {
+        String[] argsCopy = Arrays.copyOfRange(args, 1, args.length);
+
+        if (argsCopy.length > 0) {
+            DRECommand command = this.subCommands.getCommand(argsCopy[0]);
+
+            if (command != null) {
+                if (sender instanceof ConsoleCommandSender) {
+                    if (!command.isConsoleCommand()) {
+                        MessageUtil.log(CommonMessage.CMD_NO_CONSOLE_COMMAND.getMessage());
+                        return;
+                    }
+                } else if (sender instanceof Player) {
+                    Player player = (Player)sender;
+                    if (!command.isPlayerCommand()) {
+                        MessageUtil.sendMessage(player, CommonMessage.CMD_NO_PLAYER_COMMAND.getMessage());
+                        return;
+                    }
+
+                    if (!command.senderHasPermissions(player)) {
+                        MessageUtil.sendMessage(player, CommonMessage.CMD_NO_PERMISSION.getMessage());
+                        return;
+                    }
+                }
+
+                if (!(command.getMinArgs() <= argsCopy.length - 1 & command.getMaxArgs() >= argsCopy.length - 1) && command.getMinArgs() != -1) {
+                    command.displayHelp(sender);
+                    return;
+                }
+
+                command.execute(argsCopy, sender);
+                return;
+            }
+        }
+        onExecute(args, sender);
+    }
+
+    /* getter and setter */
 
     /**
      * @return the command name
@@ -163,5 +281,4 @@ public abstract class DRECommand {
      * @param sender the player or console that sent the command
      */
     public abstract void onExecute(String[] args, CommandSender sender);
-
 }

--- a/core/src/main/java/de/erethon/commons/command/DRECommand.java
+++ b/core/src/main/java/de/erethon/commons/command/DRECommand.java
@@ -18,7 +18,6 @@ import java.util.HashSet;
 import java.util.Set;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 
 /**
  * @author Daniel Saukel
@@ -26,7 +25,7 @@ import org.bukkit.entity.Player;
 public abstract class DRECommand {
 
     private String command;
-    private Set<String> aliases = new HashSet<>();
+    private final Set<String> aliases = new HashSet<>();
     private int minArgs;
     private int maxArgs;
     private String help;
@@ -39,15 +38,11 @@ public abstract class DRECommand {
     }
 
     /**
-     * @param player the player to check
-     * @return if the player has permission to use the command
+     * @param sender the sender to check
+     * @return if the sender has permission to use the command
      */
-    public boolean playerHasPermissions(Player player) {
-        if (player.hasPermission(permission) || permission == null) {
-            return true;
-        }
-
-        return false;
+    public boolean senderHasPermissions(CommandSender sender) {
+        return permission == null || permission.isEmpty() || sender.hasPermission(permission);
     }
 
     /**

--- a/core/src/main/java/de/erethon/commons/command/DRECommandExecutor.java
+++ b/core/src/main/java/de/erethon/commons/command/DRECommandExecutor.java
@@ -56,7 +56,7 @@ public class DRECommandExecutor implements CommandExecutor {
                         return false;
 
                     } else if (command.getPermission() != null) {
-                        if (!command.playerHasPermissions(player)) {
+                        if (!command.senderHasPermissions(player)) {
                             MessageUtil.sendMessage(player, CommonMessage.CMD_NO_PERMISSION.getMessage());
                             return false;
                         }
@@ -65,12 +65,11 @@ public class DRECommandExecutor implements CommandExecutor {
 
                 if (command.getMinArgs() <= args.length - 1 & command.getMaxArgs() >= args.length - 1 || command.getMinArgs() == -1) {
                     command.onExecute(args, sender);
-                    return true;
 
                 } else {
                     command.displayHelp(sender);
-                    return true;
                 }
+                return true;
             }
         }
 

--- a/core/src/main/java/de/erethon/commons/command/DRECommandExecutor.java
+++ b/core/src/main/java/de/erethon/commons/command/DRECommandExecutor.java
@@ -24,7 +24,7 @@ import org.bukkit.entity.Player;
 /**
  * The default CommandExecutor for all DRECommandCache.
  *
- * @author Frank Baumann, Daniel Saukel
+ * @author Frank Baumann, Daniel Saukel, Fyreum
  */
 public class DRECommandExecutor implements CommandExecutor {
 
@@ -64,8 +64,7 @@ public class DRECommandExecutor implements CommandExecutor {
                 }
 
                 if (command.getMinArgs() <= args.length - 1 & command.getMaxArgs() >= args.length - 1 || command.getMinArgs() == -1) {
-                    command.onExecute(args, sender);
-
+                    command.execute(args, sender);
                 } else {
                     command.displayHelp(sender);
                 }
@@ -75,12 +74,10 @@ public class DRECommandExecutor implements CommandExecutor {
 
         command = plugin.getCommandCache().getCommand("main");
         if (command != null) {
-            command.onExecute(args, sender);
-
+            command.execute(args, sender);
         } else {
             MessageUtil.sendMessage(sender, CommonMessage.CMD_DOES_NOT_EXIST.getMessage());
         }
-
         return true;
     }
 


### PR DESCRIPTION
DRECommandCache implementiert nun TabCompleter und registriert sich (falls nicht deaktiviert) selbst beim registrieren.
Es werden alle Befehle des aus dem cache vorgeschlagen, sofern der Spieler die Rechte des jeweiligen Befehls besitzt.